### PR TITLE
Add dataset ownership transfer functionality

### DIFF
--- a/app/datasets/forms.py
+++ b/app/datasets/forms.py
@@ -180,3 +180,22 @@ class CustomUserCreationForm(UserCreationForm):
         if commit:
             user.save()
         return user
+
+
+class TransferOwnershipForm(forms.Form):
+    """Form for transferring dataset ownership"""
+    new_owner = forms.ModelChoiceField(
+        queryset=User.objects.none(),
+        required=True,
+        widget=forms.Select(attrs={'class': 'form-select'}),
+        help_text="Select the user who will become the new owner of this dataset."
+    )
+
+    def __init__(self, *args, **kwargs):
+        current_owner = kwargs.pop('current_owner', None)
+        super().__init__(*args, **kwargs)
+        # Exclude the current owner from the list
+        queryset = User.objects.filter(is_active=True).order_by('username')
+        if current_owner:
+            queryset = queryset.exclude(id=current_owner.id)
+        self.fields['new_owner'].queryset = queryset

--- a/app/isrfield/urls.py
+++ b/app/isrfield/urls.py
@@ -47,6 +47,7 @@ urlpatterns = [
     path('datasets/<int:dataset_id>/custom-fields/<int:field_id>/edit/', datasets_views.custom_field_edit_view, name='custom_field_edit'),
     path('datasets/<int:dataset_id>/custom-fields/<int:field_id>/delete/', datasets_views.custom_field_delete_view, name='custom_field_delete'),
     path('datasets/<int:dataset_id>/access/', datasets_views.dataset_access_view, name='dataset_access'),
+    path('datasets/<int:dataset_id>/transfer-ownership/', datasets_views.dataset_transfer_ownership_view, name='dataset_transfer_ownership'),
     path('datasets/<int:dataset_id>/import/columns/', datasets_views.dataset_csv_column_selection_view, name='dataset_csv_column_selection'),
     path('datasets/<int:dataset_id>/import/', datasets_views.dataset_csv_import_view, name='dataset_csv_import'),
     path('datasets/<int:dataset_id>/import/summary/', datasets_views.import_summary_view, name='import_summary'),

--- a/app/templates/datasets/dataset_detail.html
+++ b/app/templates/datasets/dataset_detail.html
@@ -277,6 +277,9 @@
                         <a href="{% url 'custom_field_create' dataset.id %}" class="btn btn-outline-secondary btn-sm">
                             <i class="bi bi-plus-circle"></i> Add Custom Field
                         </a>
+                        <a href="{% url 'dataset_transfer_ownership' dataset.id %}" class="btn btn-outline-warning btn-sm">
+                            <i class="bi bi-arrow-right-circle"></i> Transfer Ownership
+                        </a>
                         <a href="{% url 'dataset_clear_data' dataset.id %}" class="btn btn-outline-danger btn-sm">
                             <i class="bi bi-eraser"></i> Clear Dataset Data
                         </a>

--- a/app/templates/datasets/dataset_transfer_ownership.html
+++ b/app/templates/datasets/dataset_transfer_ownership.html
@@ -1,0 +1,104 @@
+{% extends 'datasets/_base.html' %}
+
+{% block title %}Transfer Ownership - {{ dataset.name }}{% endblock %}
+
+{% block content %}
+<div class="container py-4" style="max-width: 800px;">
+    <div class="d-flex flex-column flex-lg-row align-items-lg-center justify-content-between gap-3 mb-4">
+        <div>
+            <h1 class="h3 mb-1">Transfer Ownership</h1>
+            <p class="text-muted small mb-0">Transfer ownership of <strong>{{ dataset.name }}</strong> to another user.</p>
+        </div>
+        <div class="d-flex flex-wrap gap-2">
+            <a href="{% url 'dataset_detail' dataset.id %}" class="btn btn-outline-secondary btn-sm">
+                <i class="bi bi-arrow-left"></i> Back to Dataset
+            </a>
+        </div>
+    </div>
+
+    {% if form.errors %}
+    <div class="alert alert-danger alert-dismissible fade show" role="alert">
+        <h5 class="alert-heading"><i class="bi bi-exclamation-triangle me-2"></i>Form Errors</h5>
+        {% if form.non_field_errors %}
+            <ul class="mb-0">
+                {% for error in form.non_field_errors %}
+                    <li>{{ error }}</li>
+                {% endfor %}
+            </ul>
+        {% else %}
+            <p class="mb-0">Please correct the errors below and try again.</p>
+        {% endif %}
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+    {% endif %}
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-warning bg-opacity-10 fw-semibold">
+            <i class="bi bi-exclamation-triangle me-2"></i>Important Information
+        </div>
+        <div class="card-body">
+            <p class="mb-2"><strong>What happens when you transfer ownership:</strong></p>
+            <ul class="mb-0 small">
+                <li>You will no longer be the owner of this dataset</li>
+                <li>The new owner will have full control over the dataset</li>
+                <li>You will retain access if you are in the shared users or groups</li>
+                <li>All data, fields, and configurations will be preserved</li>
+                <li>This action cannot be undone automatically</li>
+            </ul>
+        </div>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-light fw-semibold">
+            <i class="bi bi-info-circle me-2"></i>Current Ownership
+        </div>
+        <div class="card-body">
+            <dl class="row mb-0">
+                <dt class="col-4 text-muted">Current Owner</dt>
+                <dd class="col-8">
+                    <strong>{{ dataset.owner.username }}</strong>
+                    {% if dataset.owner.email %}
+                        <br><small class="text-muted">{{ dataset.owner.email }}</small>
+                    {% endif %}
+                </dd>
+                <dt class="col-4 text-muted">Dataset</dt>
+                <dd class="col-8">{{ dataset.name }}</dd>
+                <dt class="col-4 text-muted">Created</dt>
+                <dd class="col-8">{{ dataset.created_at|date:"F d, Y" }}</dd>
+            </dl>
+        </div>
+    </div>
+
+    <form method="post" novalidate>
+        {% csrf_token %}
+        <div class="card shadow-sm">
+            <div class="card-header bg-light fw-semibold">
+                <i class="bi bi-person-check me-2"></i>Select New Owner
+            </div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <label for="{{ form.new_owner.id_for_label }}" class="form-label fw-semibold">New Owner</label>
+                    {{ form.new_owner }}
+                    {% if form.new_owner.help_text %}
+                        <div class="form-text">{{ form.new_owner.help_text }}</div>
+                    {% endif %}
+                    {% if form.new_owner.errors %}
+                        <div class="text-danger small mt-1">
+                            {% for error in form.new_owner.errors %}{{ error }}{% endfor %}
+                        </div>
+                    {% endif %}
+                </div>
+            </div>
+            <div class="card-footer bg-light d-flex flex-wrap gap-2 justify-content-end">
+                <a href="{% url 'dataset_detail' dataset.id %}" class="btn btn-outline-secondary">
+                    <i class="bi bi-x-circle"></i> Cancel
+                </a>
+                <button type="submit" class="btn btn-warning">
+                    <i class="bi bi-arrow-right-circle"></i> Transfer Ownership
+                </button>
+            </div>
+        </div>
+    </form>
+</div>
+{% endblock %}
+


### PR DESCRIPTION
- Introduced a new form, TransferOwnershipForm, to facilitate the transfer of dataset ownership between users.
- Implemented a view, dataset_transfer_ownership_view, to handle the ownership transfer process, including permission checks and success/error messaging.
- Updated dataset detail template to include a button for transferring ownership.
- Created a new template for the ownership transfer process, providing necessary information and form for selecting a new owner.