### PR TITLE
Refactor dataset field handling to support flexible custom fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,32 +211,34 @@ When a dataset has an assigned typology:
 - **Error Handling**: Comprehensive error reporting and validation
 
 ### CSV Import Format
-The application supports various CSV formats:
+The application supports various CSV formats with flexible field names:
 
-**Standard Format**:
+**Standard Format** (example with year-prefixed columns):
 ```csv
-ID,ADRESSE,GEB_X,GEB_Y,2016_NUTZUNG,2016_CAT_INNO,2022_NUTZUNG,2022_CAT_INNO
+ID,ADRESSE,GEB_X,GEB_Y,2016_NUTZUNG,2016_CATEGORY,2022_NUTZUNG,2022_CATEGORY
 test_001,Test Address 1,656610,3399131,870,999,870,999
 test_002,Test Address 2,636410,3399724,640,0,640,0
 ```
 
 **Alternative Coordinate Formats**:
 ```csv
-ID,ADRESSE,X,Y,2016_NUTZUNG,2016_CAT_INNO
+ID,ADRESSE,X,Y,2016_NUTZUNG,2016_CATEGORY
 test_001,Test Address 1,16.3738,48.2082,870,999
 ```
 
 **Semicolon-delimited (EU)**:
 ```csv
-ID;ADRESSE;X;Y;2016_NUTZUNG;2016_CAT_INNO
+ID;ADRESSE;X;Y;2016_NUTZUNG;2016_CATEGORY
 test_001;Test Address 1;16.3738;48.2082;870;999
 ```
 
 **With Entry Names**:
 ```csv
-ID,ADRESSE,GEB_X,GEB_Y,2016_NUTZUNG,2016_CAT_INNO,NUTZUNG_NAME
+ID,ADRESSE,GEB_X,GEB_Y,2016_NUTZUNG,2016_CATEGORY,ENTRY_NAME
 test_001,Test Address 1,656610,3399131,870,999,Residential Building
 ```
+
+**Important**: Field names in your CSV are completely flexible. The system automatically creates dataset fields for any column names you use (except ID and coordinate columns). The field names in these examples (`NUTZUNG`, `CATEGORY`, `ENTRY_NAME`) are just examples - you can use any field names that make sense for your data.
 
 ### Import Features
 - **Coordinate System Detection**: Automatically detects coordinate system based on value ranges
@@ -254,7 +256,8 @@ test_001,Test Address 1,656610,3399131,870,999,Residential Building
 The application supports exporting datasets as CSV files with the following features:
 
 - **Geometry-based rows**: Each geometry point becomes a row in the CSV
-- **Year-prefixed columns**: Data entries are organized by year (e.g., `2016_USAGE_CODE1`, `2022_CAT_INNO`)
+- **Flexible field columns**: All custom fields defined in the dataset are exported as columns
+- **Year-prefixed columns**: Data entries can be organized by year (e.g., `2016_NUTZUNG`, `2022_CATEGORY`)
 - **Configurable options**: Choose whether to include coordinates and empty years
 - **Automatic formatting**: Proper CSV formatting with headers and data validation
 
@@ -263,18 +266,23 @@ The application supports exporting datasets as CSV files with the following feat
 The exported CSV contains:
 - `ID`: Unique identifier for each geometry
 - `ADRESSE`: Address of the geometry
-- `GEB_X`, `GEB_Y`: Coordinates (optional)
-- Year-prefixed columns for each data field:
-  - `USAGE_CODE1`, `USAGE_CODE2`, `USAGE_CODE3`
-  - `CAT_INNO`, `CAT_WERT`, `CAT_FILI`
+- `GEB_X`, `GEB_Y`: Coordinates (optional, if enabled)
+- `User`: Username of the user who created the geometry
+- `Entry_Name`: Name of the data entry
+- `Year`: Year associated with the entry (if available)
+- **All custom fields**: All fields defined in the dataset's field configuration are exported as columns
+
+**Note**: Field names are completely flexible. The system does not require any specific field names like `USAGE_CODE1` or `CAT_INNO` - these are just examples. You can define any field names you need for your dataset.
 
 ### Example Export
 
 ```csv
-ID,ADRESSE,GEB_X,GEB_Y,2016_USAGE_CODE1,2016_CAT_INNO,2022_USAGE_CODE1,2022_CAT_INNO
-test_001,Test Address 1,16.3738,48.2082,100,1,100,1
-test_002,Test Address 2,16.3748,48.2092,101,2,101,2
+ID,ADRESSE,GEB_X,GEB_Y,User,Entry_Name,Year,2016_NUTZUNG,2016_CATEGORY,2022_NUTZUNG,2022_CATEGORY
+test_001,Test Address 1,16.3738,48.2082,admin,Residential Building,2016,870,999,870,999
+test_002,Test Address 2,16.3748,48.2092,admin,Office Building,2022,640,0,640,0
 ```
+
+**Note**: The field names in the example (`NUTZUNG`, `CATEGORY`) are just examples. Your exported CSV will contain whatever field names you have configured in your dataset.
 
 ## Interactive Mapping
 

--- a/app/templates/datasets/dataset_csv_import.html
+++ b/app/templates/datasets/dataset_csv_import.html
@@ -58,9 +58,10 @@
 
                     <div class="alert alert-info mb-0">
                         <ul class="mb-0 small">
-                            <li><strong>Data creation:</strong> Each year-specific column creates a separate entry; generic columns create a single entry when no year columns exist.</li>
+                            <li><strong>Data creation:</strong> Each year-specific column (e.g., <code>2016_FIELDNAME</code>) creates a separate entry; generic columns create a single entry when no year columns exist.</li>
                             <li><strong>Existing IDs:</strong> Rows with geometry IDs that already exist are skipped to avoid duplicates.</li>
-                            <li><strong>Entry names:</strong> Use <code>{YEAR}_NUTZUNG_NAME</code> or <code>NUTZUNG_NAME</code> to label entries. Otherwise, names remain blank.</li>
+                            <li><strong>Entry names:</strong> Use columns like <code>{YEAR}_ENTRY_NAME</code> or <code>ENTRY_NAME</code> to label entries. Otherwise, names remain blank.</li>
+                            <li><strong>Field creation:</strong> All column names (except ID and coordinate columns) automatically become dataset fields that you can configure later.</li>
                             <li><strong>Coordinate transforms:</strong> Multiple Austrian projections are transformed to WGS84 automatically.</li>
                         </ul>
                     </div>
@@ -129,16 +130,17 @@
                 </div>
                 <div class="card-body">
                     <small class="text-muted">
-<pre class="mb-3">ID,ADRESSE,2016_NUTZUNG,2016_CAT_INNO,2016_CAT_WERT,2016_CAT_FILI,2016_NUTZUNG_NAME,GEB_X,GEB_Y,2022_NUTZUNG,2022_CAT_INNO,2022_CAT_WERT,2022_CAT_FILI,2022_NUTZUNG_NAME
+                        <p class="mb-2"><strong>Note:</strong> The field names in these examples are just examples. You can use any field names that make sense for your data.</p>
+<pre class="mb-3">ID,ADRESSE,2016_NUTZUNG,2016_CATEGORY,2016_VALUE,2016_TYPE,2016_ENTRY_NAME,GEB_X,GEB_Y,2022_NUTZUNG,2022_CATEGORY,2022_VALUE,2022_TYPE,2022_ENTRY_NAME
 ss16_kg01_001_1,Apollogasse 19,870,999,999,999,Residential Building,656.61,339913.14,870,999,999,999,Office Building
 ss16_kg01_001_2,Apollogasse 28,640,0,0,0,Commercial Space,636.41,339972.43,640,0,0,0,Retail Store
 
 Alternative coordinates:
-ID,ADRESSE,LONGITUDE,LATITUDE,2016_NUTZUNG,2016_CAT_INNO,2016_NUTZUNG_NAME
+ID,ADRESSE,LONGITUDE,LATITUDE,2016_NUTZUNG,2016_CATEGORY,2016_ENTRY_NAME
 point_001,Test Address,16.3738,48.2082,870,999,Residential Building
 
 Generic format:
-ID,ADRESSE,X,Y,NUTZUNG,CAT_INNO,CAT_WERT,NUTZUNG_NAME,YEAR
+ID,ADRESSE,X,Y,NUTZUNG,CATEGORY,VALUE,ENTRY_NAME,YEAR
 point_002,Another Address,656610,3399131,870,999,999,Office Building,2022</pre>
                     </small>
                 </div>


### PR DESCRIPTION
- Removed the legacy auto-creation of fixed standard fields, allowing all fields to behave as custom fields.
- Updated related views and templates to reflect the new field handling approach.
- Enhanced CSV import/export documentation in README to clarify flexible field naming and usage.
- Adjusted dataset field configuration management to focus solely on custom fields.