### PR TITLE
Add test for MultiPolygon support in mapping area outlines API

### DIFF
--- a/app/datasets/tests/test_access_restrictions.py
+++ b/app/datasets/tests/test_access_restrictions.py
@@ -184,6 +184,38 @@ class DatasetMappingAreaAccessTests(TestCase):
         self.assertEqual(data['mapping_areas'][0]['id'], self.mapping_area.id)
         self.assertEqual(data['mapping_areas'][0]['geometry']['type'], 'Polygon')
 
+    def test_collaborator_mapping_area_outlines_endpoint_returns_multipolygon(self):
+        """Outlines API returns GeoJSON MultiPolygon when the area has multiple parts."""
+        poly_a = Polygon(
+            ((-0.2, -0.2), (-0.2, -0.15), (-0.15, -0.15), (-0.15, -0.2), (-0.2, -0.2)),
+            srid=4326,
+        )
+        poly_b = Polygon(
+            ((0.15, 0.15), (0.15, 0.2), (0.2, 0.2), (0.2, 0.15), (0.15, 0.15)),
+            srid=4326,
+        )
+        multi_area = MappingArea.objects.create(
+            dataset=self.dataset,
+            name='Two-part area',
+            geometry=MultiPolygon(poly_a, poly_b, srid=4326),
+            created_by=self.owner,
+        )
+        DatasetUserMappingArea.objects.create(
+            dataset=self.dataset,
+            user=self.user,
+            mapping_area=multi_area,
+        )
+        url = reverse('mapping_area_outlines', args=[self.dataset.id])
+        response = self.user_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertTrue(data['success'])
+        self.assertEqual(len(data['mapping_areas']), 1)
+        self.assertEqual(data['mapping_areas'][0]['id'], multi_area.id)
+        geom = data['mapping_areas'][0]['geometry']
+        self.assertEqual(geom['type'], 'MultiPolygon')
+        self.assertEqual(len(geom['coordinates']), 2)
+
     def test_owner_mapping_area_outlines_endpoint_returns_empty(self):
         """Owners use the full mapping-areas list API; outlines stay empty."""
         url = reverse('mapping_area_outlines', args=[self.dataset.id])

--- a/app/static/js/data-input.js
+++ b/app/static/js/data-input.js
@@ -2059,21 +2059,19 @@ function drawCollaboratorMappingAreaOutlines(areas) {
     clearCollaboratorMappingAreaOutlines();
     if (!map || !areas || !areas.length) return;
     areas.forEach(function(area) {
-        if (!area.geometry || !area.geometry.coordinates) return;
-        var coordinates = area.geometry.coordinates[0];
-        var latlngs = coordinates.map(function(coord) {
-            return [coord[1], coord[0]];
-        });
-        var polygon = L.polygon(latlngs, {
-            color: '#0f766e',
-            weight: 2,
-            dashArray: '8 6',
-            opacity: 0.95,
-            fillColor: '#14b8a6',
-            fillOpacity: 0.12,
-            interactive: false
+        if (!area.geometry || !area.geometry.type) return;
+        if (area.geometry.type !== 'Polygon' && area.geometry.type !== 'MultiPolygon') return;
+        var gj = L.geoJSON(area.geometry, {
+            interactive: false,
+            style: {
+                color: '#ffc107',
+                weight: 2,
+                opacity: 0.8,
+                fillColor: '#ffc107',
+                fillOpacity: 0.2
+            }
         }).addTo(map);
-        collaboratorMappingAreaPolygons.push(polygon);
+        collaboratorMappingAreaPolygons.push(gj);
     });
 }
 

--- a/app/staticfiles/js/data-input.js
+++ b/app/staticfiles/js/data-input.js
@@ -2059,21 +2059,19 @@ function drawCollaboratorMappingAreaOutlines(areas) {
     clearCollaboratorMappingAreaOutlines();
     if (!map || !areas || !areas.length) return;
     areas.forEach(function(area) {
-        if (!area.geometry || !area.geometry.coordinates) return;
-        var coordinates = area.geometry.coordinates[0];
-        var latlngs = coordinates.map(function(coord) {
-            return [coord[1], coord[0]];
-        });
-        var polygon = L.polygon(latlngs, {
-            color: '#0f766e',
-            weight: 2,
-            dashArray: '8 6',
-            opacity: 0.95,
-            fillColor: '#14b8a6',
-            fillOpacity: 0.12,
-            interactive: false
+        if (!area.geometry || !area.geometry.type) return;
+        if (area.geometry.type !== 'Polygon' && area.geometry.type !== 'MultiPolygon') return;
+        var gj = L.geoJSON(area.geometry, {
+            interactive: false,
+            style: {
+                color: '#ffc107',
+                weight: 2,
+                opacity: 0.8,
+                fillColor: '#ffc107',
+                fillOpacity: 0.2
+            }
         }).addTo(map);
-        collaboratorMappingAreaPolygons.push(polygon);
+        collaboratorMappingAreaPolygons.push(gj);
     });
 }
 


### PR DESCRIPTION
- Implemented a new test to verify that the outlines API correctly returns a GeoJSON MultiPolygon when a mapping area consists of multiple parts.
- Updated the JavaScript function to handle both Polygon and MultiPolygon geometries, ensuring proper rendering on the map.