### PR TITLE
Add geometry deletion functionality and related tests

### DIFF
--- a/app/datasets/tests/test_data_input_js.py
+++ b/app/datasets/tests/test_data_input_js.py
@@ -203,6 +203,7 @@ class DataInputJavaScriptTestCase(TestCase):
         geometry_data = data['geometry']
         self.assertEqual(geometry_data['id'], self.geometry.id)
         self.assertEqual(geometry_data['id_kurz'], 'TEST001')
+        self.assertEqual(geometry_data['created_by_user_id'], self.user.id)
         self.assertIn('entries', geometry_data)
         
         # Check entries structure
@@ -288,6 +289,7 @@ class DataInputJavaScriptTestCase(TestCase):
         self.assertIn('lat', point)
         self.assertIn('lng', point)
         self.assertIn('user', point)
+        self.assertEqual(point['created_by_user_id'], self.user.id)
         
         # Should not contain entries or field data
         self.assertNotIn('entries', point)
@@ -416,7 +418,7 @@ class DataInputJavaScriptTestCase(TestCase):
         self.assertIn('geometry', data)
         
         geometry = data['geometry']
-        required_fields = ['id', 'id_kurz', 'address', 'lat', 'lng', 'user', 'entries']
+        required_fields = ['id', 'id_kurz', 'address', 'lat', 'lng', 'user', 'created_by_user_id', 'entries']
         for field in required_fields:
             self.assertIn(field, geometry, f"Required field {field} missing from geometry data")
         
@@ -573,3 +575,47 @@ class DataInputJavaScriptTestCase(TestCase):
         # This ensures the property name matches what JavaScript expects
         self.assertIn('non_editable', non_editable_data, "non_editable property should be in JSON")
         self.assertEqual(non_editable_data['non_editable'], True, "non_editable should be True in JSON")
+
+    def test_owner_can_delete_geometry_via_post(self):
+        """Dataset owner can delete a geometry; it is removed from the database."""
+        client = Client()
+        client.force_login(self.user)
+        gid = self.geometry.id
+        url = reverse('geometry_delete', kwargs={'geometry_id': gid})
+        response = client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json().get('success'))
+        self.assertFalse(DataGeometry.objects.filter(pk=gid).exists())
+
+    def test_shared_user_cannot_delete_others_geometry(self):
+        """Collaborators cannot delete geometries created by another user."""
+        other = User.objects.create_user(username='collab', email='c@example.com', password='pass')
+        self.dataset.shared_with.add(other)
+        client = Client()
+        client.force_login(other)
+        gid = self.geometry.id
+        url = reverse('geometry_delete', kwargs={'geometry_id': gid})
+        response = client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 403)
+        self.assertTrue(DataGeometry.objects.filter(pk=gid).exists())
+
+    def test_creator_can_delete_own_geometry(self):
+        """A logged-in user can delete a geometry they created."""
+        from django.contrib.gis.geos import Point
+
+        collab = User.objects.create_user(username='collab2', email='c2@example.com', password='pass')
+        self.dataset.shared_with.add(collab)
+        own = DataGeometry.objects.create(
+            dataset=self.dataset,
+            id_kurz='OWN001',
+            address='Own point',
+            geometry=Point(16.0, 48.1),
+            user=collab,
+        )
+        client = Client()
+        client.force_login(collab)
+        url = reverse('geometry_delete', kwargs={'geometry_id': own.id})
+        response = client.post(url, HTTP_X_REQUESTED_WITH='XMLHttpRequest')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.json().get('success'))
+        self.assertFalse(DataGeometry.objects.filter(pk=own.id).exists())

--- a/app/datasets/views/dataset_views.py
+++ b/app/datasets/views/dataset_views.py
@@ -1143,7 +1143,8 @@ def dataset_map_data_view(request, dataset_id):
                     'address': geometry.address,
                     'lat': geometry.geometry.y,
                     'lng': geometry.geometry.x,
-                    'user': geometry.get_creator_display_name()
+                    'user': geometry.get_creator_display_name(),
+                    'created_by_user_id': geometry.user_id,
                 }
                 map_data.append(map_point)
             except Exception:

--- a/app/datasets/views/geometry_views.py
+++ b/app/datasets/views/geometry_views.py
@@ -126,6 +126,7 @@ def geometry_details_view(request, geometry_id):
             'lat': geometry.geometry.y,
             'lng': geometry.geometry.x,
             'user': geometry.get_creator_display_name(),
+            'created_by_user_id': geometry.user_id,
             'entries': []
         }
         for entry in geometry.entries.all():
@@ -153,5 +154,28 @@ def geometry_details_view(request, geometry_id):
             'geometry': geometry_data
         })
         
+    except Exception as e:
+        return JsonResponse({'success': False, 'error': str(e)}, status=500)
+
+
+@login_required
+def geometry_delete_view(request, geometry_id):
+    """Delete a geometry point (dataset owner, superuser, or logged-in creator with area access)."""
+    if request.method != 'POST':
+        return JsonResponse({'success': False, 'error': 'Only POST method allowed'}, status=405)
+    try:
+        geometry = get_object_or_404(DataGeometry, pk=geometry_id)
+        dataset = geometry.dataset
+        if not dataset.can_access(request.user):
+            return JsonResponse({'success': False, 'error': 'Access denied'}, status=403)
+        if request.user.is_superuser or request.user == dataset.owner:
+            geometry.delete()
+            return JsonResponse({'success': True})
+        if geometry.user_id == request.user.id:
+            if not dataset.user_has_geometry_access(request.user, geometry):
+                return JsonResponse({'success': False, 'error': 'Access denied'}, status=403)
+            geometry.delete()
+            return JsonResponse({'success': True})
+        return JsonResponse({'success': False, 'error': 'Access denied'}, status=403)
     except Exception as e:
         return JsonResponse({'success': False, 'error': str(e)}, status=500)

--- a/app/isrfield/urls.py
+++ b/app/isrfield/urls.py
@@ -70,6 +70,7 @@ urlpatterns = [
     path('datasets/<int:dataset_id>/fields/', datasets_views.dataset_fields_view, name='dataset_fields'),
     path('datasets/<int:dataset_id>/map-data/', datasets_views.dataset_map_data_view, name='dataset_map_data'),
     path('datasets/geometry/<int:geometry_id>/details/', datasets_views.geometry_details_view, name='geometry_details'),
+    path('datasets/geometry/<int:geometry_id>/delete/', datasets_views.geometry_delete_view, name='geometry_delete'),
     path('datasets/<int:dataset_id>/clear-data/', datasets_views.dataset_clear_data_view, name='dataset_clear_data'),
     path('datasets/<int:dataset_id>/geometries/create/', datasets_views.geometry_create_view, name='geometry_create'),
     path('entries/<int:entry_id>/edit/', datasets_views.entry_edit_view, name='entry_edit'),

--- a/app/static/js/data-input.js
+++ b/app/static/js/data-input.js
@@ -307,7 +307,73 @@ function showGeometryDetails(point) {
     detailsDiv.classList.add('active');
     generateEntriesTable(point);
     loadUploadedFiles();
+    updateDeleteGeometryButton();
     if (typeof adjustColumnLayout === 'function') adjustColumnLayout();
+}
+
+function updateDeleteGeometryButton() {
+    var btn = document.getElementById('deleteGeometryBtn');
+    if (!btn) return;
+    var uid = window.currentUserId;
+    var creatorId = currentPoint && currentPoint.created_by_user_id;
+    var isCreator = uid != null && creatorId != null &&
+        Number(creatorId) === Number(uid);
+    var canDelete = window.isDatasetOwner ||
+        (currentPoint && currentPoint.id != null && isCreator);
+    if (canDelete) {
+        btn.classList.remove('d-none');
+        btn.setAttribute('data-geometry-id', String(currentPoint.id));
+    } else {
+        btn.classList.add('d-none');
+        btn.removeAttribute('data-geometry-id');
+    }
+}
+
+function deleteCurrentGeometry() {
+    var btn = document.getElementById('deleteGeometryBtn');
+    if (!btn) return;
+    var uid = window.currentUserId;
+    var creatorId = currentPoint && currentPoint.created_by_user_id;
+    var isCreator = uid != null && creatorId != null &&
+        Number(creatorId) === Number(uid);
+    if (!window.isDatasetOwner && !isCreator) return;
+    var gid = btn.getAttribute('data-geometry-id');
+    if (!gid) return;
+    var msg = (window.translations && window.translations.deleteGeometryConfirm) ?
+        window.translations.deleteGeometryConfirm :
+        'Delete this geometry point and all its entries? This cannot be undone.';
+    if (!confirm(msg)) return;
+    var csrfEl = document.querySelector('[name=csrfmiddlewaretoken]');
+    if (!csrfEl || !csrfEl.value) {
+        alert((window.translations && window.translations.deleteGeometryFailed) || 'Could not delete geometry.');
+        return;
+    }
+    fetch(window.location.origin + '/datasets/geometry/' + gid + '/delete/', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+            'X-CSRFToken': csrfEl.value,
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    })
+        .then(function(response) {
+            return response.json().then(function(data) {
+                return { ok: response.ok, data: data };
+            });
+        })
+        .then(function(result) {
+            if (result.ok && result.data && result.data.success) {
+                clearSelection();
+                loadMapData(true);
+            } else {
+                var err = (result.data && result.data.error) ? result.data.error :
+                    ((window.translations && window.translations.deleteGeometryFailed) || 'Could not delete geometry.');
+                alert(err);
+            }
+        })
+        .catch(function() {
+            alert((window.translations && window.translations.deleteGeometryFailed) || 'Could not delete geometry.');
+        });
 }
 
 // Global variable to track selected entry
@@ -1737,6 +1803,12 @@ function clearSelection() {
     // Adjust column layout
     if (typeof adjustColumnLayout === 'function') {
         adjustColumnLayout();
+    }
+
+    var deleteBtn = document.getElementById('deleteGeometryBtn');
+    if (deleteBtn) {
+        deleteBtn.classList.add('d-none');
+        deleteBtn.removeAttribute('data-geometry-id');
     }
 }
 

--- a/app/staticfiles/js/data-input.js
+++ b/app/staticfiles/js/data-input.js
@@ -307,7 +307,73 @@ function showGeometryDetails(point) {
     detailsDiv.classList.add('active');
     generateEntriesTable(point);
     loadUploadedFiles();
+    updateDeleteGeometryButton();
     if (typeof adjustColumnLayout === 'function') adjustColumnLayout();
+}
+
+function updateDeleteGeometryButton() {
+    var btn = document.getElementById('deleteGeometryBtn');
+    if (!btn) return;
+    var uid = window.currentUserId;
+    var creatorId = currentPoint && currentPoint.created_by_user_id;
+    var isCreator = uid != null && creatorId != null &&
+        Number(creatorId) === Number(uid);
+    var canDelete = window.isDatasetOwner ||
+        (currentPoint && currentPoint.id != null && isCreator);
+    if (canDelete) {
+        btn.classList.remove('d-none');
+        btn.setAttribute('data-geometry-id', String(currentPoint.id));
+    } else {
+        btn.classList.add('d-none');
+        btn.removeAttribute('data-geometry-id');
+    }
+}
+
+function deleteCurrentGeometry() {
+    var btn = document.getElementById('deleteGeometryBtn');
+    if (!btn) return;
+    var uid = window.currentUserId;
+    var creatorId = currentPoint && currentPoint.created_by_user_id;
+    var isCreator = uid != null && creatorId != null &&
+        Number(creatorId) === Number(uid);
+    if (!window.isDatasetOwner && !isCreator) return;
+    var gid = btn.getAttribute('data-geometry-id');
+    if (!gid) return;
+    var msg = (window.translations && window.translations.deleteGeometryConfirm) ?
+        window.translations.deleteGeometryConfirm :
+        'Delete this geometry point and all its entries? This cannot be undone.';
+    if (!confirm(msg)) return;
+    var csrfEl = document.querySelector('[name=csrfmiddlewaretoken]');
+    if (!csrfEl || !csrfEl.value) {
+        alert((window.translations && window.translations.deleteGeometryFailed) || 'Could not delete geometry.');
+        return;
+    }
+    fetch(window.location.origin + '/datasets/geometry/' + gid + '/delete/', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+            'X-CSRFToken': csrfEl.value,
+            'X-Requested-With': 'XMLHttpRequest'
+        }
+    })
+        .then(function(response) {
+            return response.json().then(function(data) {
+                return { ok: response.ok, data: data };
+            });
+        })
+        .then(function(result) {
+            if (result.ok && result.data && result.data.success) {
+                clearSelection();
+                loadMapData(true);
+            } else {
+                var err = (result.data && result.data.error) ? result.data.error :
+                    ((window.translations && window.translations.deleteGeometryFailed) || 'Could not delete geometry.');
+                alert(err);
+            }
+        })
+        .catch(function() {
+            alert((window.translations && window.translations.deleteGeometryFailed) || 'Could not delete geometry.');
+        });
 }
 
 // Global variable to track selected entry
@@ -1737,6 +1803,12 @@ function clearSelection() {
     // Adjust column layout
     if (typeof adjustColumnLayout === 'function') {
         adjustColumnLayout();
+    }
+
+    var deleteBtn = document.getElementById('deleteGeometryBtn');
+    if (deleteBtn) {
+        deleteBtn.classList.add('d-none');
+        deleteBtn.removeAttribute('data-geometry-id');
     }
 }
 

--- a/app/templates/datasets/dataset_data_input.html
+++ b/app/templates/datasets/dataset_data_input.html
@@ -19,11 +19,18 @@
                 
                 <!-- Geometry Details Overlay/Inline -->
                 <div id="geometryDetails" class="geometry-details">
-                    <div class="d-flex justify-content-between align-items-center mb-3">
+                    <div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
                         <h5 class="mb-0">{% trans "Geometry Details" %}</h5>
-                        <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearSelection()" title="{% trans 'Clear Selection' %}">
-                            <i class="bi bi-x-circle"></i> {% trans "Close" %}
-                        </button>
+                        <div class="d-flex align-items-center gap-2 ms-auto">
+                            {% if user.is_authenticated %}
+                            <button type="button" id="deleteGeometryBtn" class="btn btn-sm btn-outline-danger d-none" onclick="deleteCurrentGeometry()" title="{% trans 'Delete this geometry point' %}">
+                                <i class="bi bi-trash"></i> {% trans "Delete" %}
+                            </button>
+                            {% endif %}
+                            <button type="button" class="btn btn-sm btn-outline-secondary" onclick="clearSelection()" title="{% trans 'Clear Selection' %}">
+                                <i class="bi bi-x-circle"></i> {% trans "Close" %}
+                            </button>
+                        </div>
                     </div>
                     
                     <div id="entriesSection">
@@ -205,6 +212,7 @@
     console.log('window.allFields initialized:', window.allFields);
     window.allowMultipleEntries = {% if allow_multiple_entries %}true{% else %}false{% endif %};
     window.datasetId = {{ dataset.id }};
+    window.currentUserId = {% if user.is_authenticated %}{{ user.id }}{% else %}null{% endif %};
     window.isDatasetOwner = {% if user.is_authenticated %}{% if dataset.owner == user or user.is_superuser %}true{% else %}false{% endif %}{% else %}false{% endif %};
     {# Only owner/superuser should load or draw mapping-area polygons; collaborators keep the flag false. #}
     window.enableMappingAreas = {% if enable_mapping_areas and user.is_authenticated %}{% if dataset.owner == user or user.is_superuser %}true{% else %}false{% endif %}{% else %}false{% endif %};
@@ -226,7 +234,9 @@
         'createEntry': '{% trans "Create New Entry" %}',
         'saveEntries': '{% trans "Save Changes" %}',
         'geolocationNotSupported': '{% trans "Geolocation is not supported by this browser." %}',
-        'geolocationError': '{% trans "Error getting your location: " %}'
+        'geolocationError': '{% trans "Error getting your location: " %}',
+        'deleteGeometryConfirm': '{% trans "Delete this geometry point and all its entries? This cannot be undone." %}',
+        'deleteGeometryFailed': '{% trans "Could not delete geometry." %}'
     };
 </script>
 {% endblock %}


### PR DESCRIPTION
- Implemented the ability for dataset owners and creators to delete geometries via a new endpoint.
- Added JavaScript functions to handle the delete action and update the UI accordingly.
- Enhanced geometry details view to include the creator's user ID for access control.
- Updated tests to verify that only authorized users can delete geometries, ensuring proper access control.
- Modified templates and JavaScript to support the new delete functionality, including confirmation prompts.