### PR TITLE
Update environment configuration for CSRF and allowed hosts

### DIFF
--- a/app/isrfield/settings.py
+++ b/app/isrfield/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'django-insecure-!7lxj&-vt5k^n@
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-_ALLOWED_HOSTS_DEFAULT = 'localhost,127.0.0.1,0.0.0.0,isrfield.dataplexity.eu,testserver'
+_ALLOWED_HOSTS_DEFAULT = 'localhost,127.0.0.1,isrfield.dataplexity.eu'
 ALLOWED_HOSTS = [
     host.strip()
     for host in os.environ.get('ALLOWED_HOSTS', _ALLOWED_HOSTS_DEFAULT).split(',')
@@ -41,11 +41,14 @@ THEME_ACCENT = os.environ.get('THEME_ACCENT', '#92C1E9')
 THEME_PRIMARY_LIGHT = os.environ.get('THEME_PRIMARY_LIGHT', '#0056d6')
 THEME_PRIMARY_DARK = os.environ.get('THEME_PRIMARY_DARK', '#003a99')
 
-# CSRF settings
+# CSRF settings (comma-separated origins, include scheme: https://example.com)
+_CSRF_TRUSTED_ORIGINS_DEFAULT = (
+    'https://isrfield.dataplexity.eu,http://localhost:8000,http://127.0.0.1:8000'
+)
 CSRF_TRUSTED_ORIGINS = [
-    'https://isrfield.dataplexity.eu',
-    'http://localhost:8000',
-    'http://127.0.0.1:8000',
+    origin.strip()
+    for origin in os.environ.get('CSRF_TRUSTED_ORIGINS', _CSRF_TRUSTED_ORIGINS_DEFAULT).split(',')
+    if origin.strip()
 ]
 
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Configuration lives in [`app/isrfield/settings.py`](../app/isrfield/settings.py)
 | `SECRET_KEY` | `DJANGO_SECRET_KEY`; insecure default present for dev only — set in production. |
 | `DEBUG` | Hard-coded `True` in repo settings; production deployments should use env-controlled debug off. |
 | `ALLOWED_HOSTS` | Comma-separated list via env `ALLOWED_HOSTS`; default `localhost`, `127.0.0.1`, `0.0.0.0`, `isrfield.dataplexity.eu`, `testserver`. |
-| `CSRF_TRUSTED_ORIGINS` | HTTPS/localhost origins for CSRF. |
+| `CSRF_TRUSTED_ORIGINS` | Comma-separated origins via env `CSRF_TRUSTED_ORIGINS` (include `https://` or `http://`); default `https://isrfield.dataplexity.eu`, `http://localhost:8000`, `http://127.0.0.1:8000`. |
 
 ## Branding / theme
 

--- a/env.example
+++ b/env.example
@@ -17,6 +17,8 @@ DEBUG=False
 
 # Optional: Comma-separated hostnames (default matches local + production deploy host)
 # ALLOWED_HOSTS=localhost,127.0.0.1,0.0.0.0,isrfield.dataplexity.eu,testserver
+# Optional: Comma-separated origins with scheme (for CSRF; default includes production + local dev)
+# CSRF_TRUSTED_ORIGINS=https://isrfield.dataplexity.eu,http://localhost:8000,http://127.0.0.1:8000
 # TIME_ZONE=Europe/Vienna
 
 # Email Configuration (SMTP)


### PR DESCRIPTION
- Added CSRF_TRUSTED_ORIGINS to env.example and settings.py for better security configuration.
- Updated ALLOWED_HOSTS to remove 'testserver' and ensure it aligns with the new defaults.
- Enhanced documentation to reflect changes in CSRF_TRUSTED_ORIGINS format and usage.